### PR TITLE
Run on Node 20 rather than Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
     required: false
     default: 'true'
 runs:
-  using: node16
+  using: node20
   main: ./dist/index.js
 branding:
   icon: trash-2


### PR DESCRIPTION
Node 16 has reached EOL and is deprecated. GitHub is transitioning to Node 20:

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/